### PR TITLE
added timeout support for linux

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -8,7 +8,7 @@ License: MIT + file LICENSE
 LazyData: true
 URL: https://github.com/gaborcsardi/notifier
 BugReports: https://github.com/gaborcsardi/notifier/issues
-RoxygenNote: 5.0.1.9000
+RoxygenNote: 5.0.1
 Roxygen: list(markdown = TRUE)
 Imports:
     utils

--- a/R/linux.R
+++ b/R/linux.R
@@ -1,5 +1,5 @@
 
-notify_linux <- function(msg, title, image) {
+notify_linux <- function(msg, title, image, timeout) {
 
   ns <- Sys.which("notify-send")
 
@@ -16,8 +16,12 @@ notify_linux <- function(msg, title, image) {
     image <- normalizePath(system.file(package = packageName(), "R.png"))
   }
 
+  expire <- as.integer(1e3L*timeout)
+  if (is.na(expire)) expire <- 1e3L*10L
+  
   args <- c(
     "-i", shQuote(image),
+    "-t", expire,
     shQuote(title),
     shQuote(msg)
   )

--- a/R/notify.R
+++ b/R/notify.R
@@ -37,6 +37,7 @@ detect_os <- function() {
 #'   file here, to show instead of the R logo. This currently does not
 #'   work on older Windows versions (before Windows 8), which does not
 #'   allow PNG files, only ICO icons.
+#' @param timeout Number of seconds before notification expires (currently linux only).
 #'
 #' @export
 #' @examples
@@ -46,7 +47,7 @@ detect_os <- function() {
 #' notify("Hello world!", title = "Introduction", image = "mylogo.png")
 #' }
 
-notify <- function(msg, title = "R notification", image = NULL) {
+notify <- function(msg, title = "R notification", image = NULL, timeout = 10L) {
 
   stopifnot(
     is.character(msg),
@@ -55,11 +56,13 @@ notify <- function(msg, title = "R notification", image = NULL) {
   )
 
   msg <- paste(msg, collapse = " ")
+  timeout <- as.numeric(timeout)
+  stopifnot(!is.na(timeout))
 
   switch(
     detect_os(),
     windows = notify_windows(msg, title, image),
     macos   = notify_macos(msg, title, image),
-    linux   = notify_linux(msg, title, image)
+    linux   = notify_linux(msg, title, image, timeout)
   )
 }

--- a/man/notify.Rd
+++ b/man/notify.Rd
@@ -4,7 +4,7 @@
 \alias{notify}
 \title{Create a desktop notification}
 \usage{
-notify(msg, title = "R notification", image = NULL)
+notify(msg, title = "R notification", image = NULL, timeout = 10L)
 }
 \arguments{
 \item{msg}{Message to show. It may contain newline characters.}
@@ -18,21 +18,21 @@ on other OSes, because of licensing reasons. You can specify a PNG
 file here, to show instead of the R logo. This currently does not
 work on older Windows versions (before Windows 8), which does not
 allow PNG files, only ICO icons.}
+
+\item{timeout}{Number of seconds before notification expires (currently linux only).}
 }
 \description{
 How exactly the notification appears is platform dependent:
-\itemize{
-\item On macOS, we use the \code{terminal-notifier} tool, see
-https://github.com/julienXX/terminal-notifier
-\item On Linux and *BSD systems, including Solaris the \code{notify-send}
-command line tool is used. This requires the \code{libnotify-bin}
-package on Ubuntu/Debian and similar systems, or the \code{libnotify}
-package on RedHat/CentOS/Fedora and similar systems.
-\item On Windows 8 or newer Windows versions we use the \code{toaster} tool,
-see https://github.com/nels-o/toaster.
-\item On older Windows versions we use the \code{notifu} program, see
-https://www.paralint.com/projects/notifu.
-}
+* On macOS, we use the `terminal-notifier` tool, see
+  https://github.com/julienXX/terminal-notifier
+* On Linux and *BSD systems, including Solaris the `notify-send`
+  command line tool is used. This requires the `libnotify-bin`
+  package on Ubuntu/Debian and similar systems, or the `libnotify`
+  package on RedHat/CentOS/Fedora and similar systems.
+* On Windows 8 or newer Windows versions we use the `toaster` tool,
+  see https://github.com/nels-o/toaster.
+* On older Windows versions we use the `notifu` program, see
+  https://www.paralint.com/projects/notifu.
 }
 \details{
 All notification systems support showing a title and an image,


### PR DESCRIPTION
In `notify-send` at least, there's an `expire-time` flag (`-t`) that can be set (timeout in millseconds). This would be a useful option to retain if possible. I've resorted to using pushbullet to send notifications of completed jobs around, and `notifier` would solve that problem for me if it weren't for the fact that the notification expires by default after 10 seconds.

I'm not familiar enough with the other systems to know if they have similar options.