### PR TITLE
Changing regex code used to extract version in windows_version()

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -17,7 +17,7 @@ windows_version <- (function() {
     }
     
     ver <- paste(ver, collapse = "")  
-    ver <- sub("^.*Version[ ]+([0-9\\.]+).*$", "\\1", ver, perl = TRUE)
+    ver <- sub("^.*(?i)Version[ ]+([0-9\\.]+)(?-i).*$", "\\1", ver, perl = TRUE)
     ver <- package_version(ver)
 
     version <<- ver


### PR DESCRIPTION
regex code which match "version" is now case insensitive. (see, #7)