### PR TITLE
Updated terminal-notifier path

### DIFF
--- a/R/macos.R
+++ b/R/macos.R
@@ -4,7 +4,7 @@
 notify_macos <- function(msg, title, image) {
 
   tn <- system.file(package = packageName(),
-                    "tn", "bin", "terminal-notifier")
+                    "tn", "terminal-notifier", "bin", "terminal-notifier")
 
   if (!file.exists(tn)) {
     stop("Cannot find terminal-notifier executable, ", sQuote("notifier"),


### PR DESCRIPTION
At least on my system the terminal-notifier is copied to
R_LIB/notifier/tn/terminal-notifier/bin/terminal-notifier

I don't think I have any non-defaults set in homebrew or on the R side, so not sure why the paths would be different.